### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Clone the project in `~/.config`:
 
-    git clone git@github.com:vjousse/neovim-from-scratch.git ~/.config
+    git clone git@github.com:vjousse/neovim-from-scratch.git ~/.config/nvim
 
 Start `nvim` with this configuration:
 


### PR DESCRIPTION
This repository should be made available in `~/.config/nvim` rather than `~/.config` for the rest of instructions to work.

PS: Thanks for this guide!